### PR TITLE
luci-app-cjdns: fix invalid XML

### DIFF
--- a/luci-app-cjdns/luasrc/view/cjdns/status.htm
+++ b/luci-app-cjdns/luasrc/view/cjdns/status.htm
@@ -60,6 +60,7 @@
 
 <script type="text/javascript">
 <%# Author: [GitHub/75lb] -%>
+//<![CDATA[
 function lbbytes (bytes){
 
 	var kilobyte = 1024,
@@ -81,6 +82,7 @@ function lbbytes (bytes){
 		return bytes + " B";
 	}
 };
+//]]>
 </script>
 
 <fieldset class="cbi-section">


### PR DESCRIPTION
JavaScript source included in status.htm didn't escape from XML context.
Fix that by adding
//<![CDATA[
//]]>
construct.
This is needed so browsers don't get confused (some did).

Signed-off-by: Daniel Golle daniel@makrotopia.org
