### PR TITLE
[meshbox/luci-app-cjdns] Logic/Variable fix of Admin API status 

### DIFF
--- a/luci-app-cjdns/luasrc/view/cjdns/status.htm
+++ b/luci-app-cjdns/luasrc/view/cjdns/status.htm
@@ -7,8 +7,8 @@
 			table.deleteRow(1);
 		}
 
-		if ((peers == null) || (typeof peers.length === 'undefined')) {
-			var errpeer = (! peers)
+		if ((peers) && ((peers.err) || (typeof peers.length === 'undefined'))) {
+			var errpeer = (peers.err)
 						? 'Socket Error: unable to connect to Admin API'
 						: 'No active peers';
 			var row = table.insertRow(-1);


### PR DESCRIPTION
Code detects getCookie > timeout in the peers.err object. Tested 3 states (no process, 0 peers, 1+ peers)
