### PR TITLE
Add cjdns firewall zone and rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Then build with `make`. You can append `-j $n`, where n is the number of CPU thr
 
 *Note:* The master branch is for development against OpenWrt Chaos Calmer (trunk). Unless you know what you're doing, you should always use OpenWrt Barrier Breaker (14.07), and the for-14.07 branch of Meshbox.
 
-**WARNING:** After installation, be aware that everybody on the cjdns network will be able to access your LuCI and SSH. Reconfigure the services to bind to specific interfaces only, or add tun0 to the WAN firewall zone. Furthermore, do make sure that all passwords, especially for root, are sufficiently secure. This is not a shortcoming of cjdns, but rather a problem with the services' default configurations, which instruct them to listen on all existing interfaces.
-
 
 Contact
 -------

--- a/cjdns/files/cjdns.defaults
+++ b/cjdns/files/cjdns.defaults
@@ -17,18 +17,20 @@ EOF
   cjdroute --genconf | cjdroute --cleanconf | cjdrouteconf set
 
   # enable auto-peering on ethernet
-  section=$(uci add cjdns eth_interface)
-  uci set cjdns.$section.beacon=2
   uci show network.lan | grep type=bridge >/dev/null 2>&1
   if [ $? -eq 0 ]; then
     # most routers will set up an ethernet bridge for the lan
-    uci set cjdns.$section.bind=br-lan
+    ifname="br-lan"
   else
     # docker containers don't have permission to create bridges by default,
     # so we bind to the underlying interface instead (likely eth0)
     ifname=$(uci get network.lan.ifname)
-    uci set cjdns.$section.bind=$ifname
   fi
+  uci -q batch <<-EOF >/dev/null
+    add cjdns eth_interface
+    set cjdns.@eth_interface[-1].beacon=2
+    set cjdns.@eth_interface[-1].bind=$ifname
+EOF
 
   uci commit cjdns
 

--- a/cjdns/files/cjdns.defaults
+++ b/cjdns/files/cjdns.defaults
@@ -32,7 +32,87 @@ EOF
     set cjdns.@eth_interface[-1].bind=$ifname
 EOF
 
+  # set the tun interface name
+  uci set cjdns.cjdns.tun_device=tuncjdns
+
+  # create the network interface
+  uci -q batch <<-EOF >/dev/null
+    set network.cjdns=interface
+    set network.cjdns.ifname=tuncjdns
+    set network.cjdns.proto=none
+EOF
+
+  # firewall rules by @dangowrt -- thanks <3
+
+  # create the firewall zone
+  uci -q batch <<-EOF >/dev/null
+    add firewall zone
+    set firewall.@zone[-1].name=cjdns
+    add_list firewall.@zone[-1].network=cjdns
+    set firewall.@zone[-1].input=REJECT
+    set firewall.@zone[-1].output=ACCEPT
+    set firewall.@zone[-1].forward=REJECT
+    set firewall.@zone[-1].conntrack=1
+    set firewall.@zone[-1].family=ipv6
+EOF
+
+  # allow ICMP from cjdns zone, e.g. ping6
+  uci -q batch <<-EOF >/dev/null
+    add firewall rule
+    set firewall.@rule[-1].name='Allow-ICMPv6-cjdns'
+    set firewall.@rule[-1].src=cjdns
+    set firewall.@rule[-1].proto=icmp
+    add_list firewall.@rule[-1].icmp_type=echo-request
+    add_list firewall.@rule[-1].icmp_type=echo-reply
+    add_list firewall.@rule[-1].icmp_type=destination-unreachable
+    add_list firewall.@rule[-1].icmp_type=packet-too-big
+    add_list firewall.@rule[-1].icmp_type=time-exceeded
+    add_list firewall.@rule[-1].icmp_type=bad-header
+    add_list firewall.@rule[-1].icmp_type=unknown-header-type
+    set firewall.@rule[-1].limit='1000/sec'
+    set firewall.@rule[-1].family=ipv6
+    set firewall.@rule[-1].target=ACCEPT
+EOF
+
+  # allow SSH from cjdns zone, needs to be explicitly enabled
+  uci -q batch <<-EOF >/dev/null
+    add firewall rule
+    set firewall.@rule[-1].enabled=0
+    set firewall.@rule[-1].name='Allow-SSH-cjdns'
+    set firewall.@rule[-1].src=cjdns
+    set firewall.@rule[-1].proto=tcp
+    set firewall.@rule[-1].dest_port=22
+    set firewall.@rule[-1].target=ACCEPT
+EOF
+
+  # allow LuCI access from cjdns zone, needs to be explicitly enabled
+  uci -q batch <<-EOF >/dev/null
+    add firewall rule
+    set firewall.@rule[-1].enabled=0
+    set firewall.@rule[-1].name='Allow-HTTP-cjdns'
+    set firewall.@rule[-1].src=cjdns
+    set firewall.@rule[-1].proto=tcp
+    set firewall.@rule[-1].dest_port=80
+    set firewall.@rule[-1].target=ACCEPT
+EOF
+
+  # allow UDP peering from wan zone, if it exists
+  uci show network.wan >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    peeringPort=$(uci get cjdns.@udp_interface[0].port)
+    uci -q batch <<-EOF >/dev/null
+      add firewall rule
+      set firewall.@rule[-1].name='Allow-cjdns-wan'
+      set firewall.@rule[-1].src=wan
+      set firewall.@rule[-1].proto=udp
+      set firewall.@rule[-1].dest_port=$peeringPort
+      set firewall.@rule[-1].target=ACCEPT
+EOF
+  fi
+
   uci commit cjdns
+  uci commit firewall
+  uci commit network
 
 fi
 


### PR DESCRIPTION
Here come the firewall settings

- adds a network interface covering the `tuncjdns` interface
- rejects incoming traffic from cjdns
- allows ICMP from cjdns
- allows HTTP/LuCI access from cjdns (this rule is disabled by default)
- allows SSH from cjdns (this rule is disabled by default)
- if there's a wan zone, allows UDP peering from wan

WDYT?